### PR TITLE
add community guideline files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @traveloka/techops

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+ advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+ address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+ professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at site-infra{at}traveloka(dot)com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,0 +1,116 @@
+---
+name: Bug Report
+about: Report if something is not working as expected
+labels: bug
+title: "[BUG] <add_your_clear_and_concise_title_here>"
+---
+
+
+### Community Note
+<!---
+No need to modify anything within this section.
+--->
+
+* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
+* Please do not leave "+1" or "me too" comments, they generate extra noise for issue followers and do not help prioritize the request
+* ***If you are interested in working on this issue or have submitted a pull request, please leave a comment!***
+
+***
+
+### Summary
+<!---
+A clear and concise description of what the bug is.
+Don't forget to fill additional data below in order to help us helping you.
+--->
+
+### Module Version
+<!---
+State the version of the module where you experience the bug.
+--->
+
+
+### Terraform Version and Terraform AWS Provider Version
+<!--- 
+Please run `terraform -v` to show the Terraform core version and provider version(s). 
+
+If you are not running the latest version of Terraform or the provider, please upgrade because your issue may have already been fixed. [Terraform documentation on provider versioning](https://www.terraform.io/docs/configuration/providers.html#provider-versions).
+--->
+
+```
+Terraform vX.XX.XX
++ provider.aws vX.XX.XX
+```
+
+
+### Affected Resource(s)
+<!---
+Please list the affected resources and data sources.
+--->
+
+* aws_XXXXX
+
+
+### Terraform Configuration Files
+<!---
+Information about code formatting: https://help.github.com/articles/basic-writing-and-formatting-syntax/#quoting-code
+--->
+
+```hcl
+# Copy-paste your Terraform configurations here.
+# For large Terraform configs, please use a service like Google Drive and share a link to the ZIP file.
+```
+
+
+### Expected Behavior
+<!---
+What should have happened?
+--->
+
+
+### Actual Behavior
+<!---
+What actually happened?
+--->
+
+
+### Screnshots
+<!---
+If applicable, add screenshots to help explain your problem.
+--->
+
+
+### Steps to Reproduce
+<!---
+Please list the steps required to reproduce the issue.
+--->
+
+1. `terraform apply`
+2. `<any_command_you_executed>`
+
+
+### Important Factoids
+<!---
+Are there anything atypical about your accounts that we should know? 
+For example: Running in EC2 Classic?
+--->
+
+
+### References
+<!---
+Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests
+
+Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation? For example:
+
+* https://aws.amazon.com/about-aws/whats-new/2018/04/introducing-amazon-ec2-fleet/
+--->
+
+* #0000
+
+
+<!---
+Credit: 
+This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/ISSUE_TEMPLATE/Bug_Report.md
+
+Created: May 20, 2019 
+Last updated: July 11, 2019
+--->

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,0 +1,63 @@
+---
+name: Feature Request
+about: Give suggestion(s) of what needs to be done to improve this module
+labels: enhancement
+title: "[ENHANCEMENT] <add_your_clear_and_concise_title_here>"
+---
+
+
+### Community Note
+<!---
+No need to modify anything within this section.
+--->
+
+* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
+* Please do not leave "+1" or "me too" comments, they generate extra noise for issue followers and do not help prioritize the request
+* ***If you have submitted a pull request addressing the same issue, please leave a comment!***
+
+***
+
+### Description
+<!---
+Please leave a helpful description of the feature request here.
+--->
+
+
+### New or Affected Resource(s)
+<!--- 
+Please list the new or affected resources and data sources.
+--->
+
+* aws_XXXXX
+
+
+### Potential Terraform Configuration Changes
+<!---
+Information about code formatting: https://help.github.com/articles/basic-writing-and-formatting-syntax/#quoting-code
+--->
+
+```hcl
+# Copy-paste your Terraform configurations here.
+# For large Terraform configs, please use a service like Google Drive and share a link to the ZIP file.
+```
+
+
+### References
+<!---
+Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests
+
+Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation? For example:
+
+* https://aws.amazon.com/about-aws/whats-new/2018/04/introducing-amazon-ec2-fleet/
+--->
+
+* #0000
+
+
+<!---
+Credit: 
+This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/ISSUE_TEMPLATE/Feature_Request.md
+
+Created: May 20, 2019 
+Last updated: July 11, 2019
+--->

--- a/.github/ISSUE_TEMPLATE/GENERAL_QUESTION.md
+++ b/.github/ISSUE_TEMPLATE/GENERAL_QUESTION.md
@@ -1,0 +1,31 @@
+---
+name: General Question
+about: Unsure about something? Have anything to discuss?
+labels: question
+title: "[QUESTION] <add_your_clear_and_concise_title_here>"
+---
+
+
+### Community Note
+<!---
+No need to modify anything within this section.
+--->
+
+* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
+* Please do not leave "+1" or "me too" comments, they generate extra noise for issue followers and do not help prioritize the request
+
+***
+
+### Question
+<!---
+Please leave a clear question here
+--->
+
+
+<!---
+Credit: 
+This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/ISSUE_TEMPLATE/Feature_Request.md
+
+Created: July 11, 2019 
+Last updated: -
+--->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,59 @@
+<!--- 
+See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
+--->
+
+### Community Note
+<!---
+No need to modify anything within this section.
+--->
+* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
+* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request
+
+***
+
+<!---
+State an issue that you address on this PR.
+--->
+Fixes #0000
+
+***
+
+Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-s3-bucket/blob/master/CHANGELOG.md):
+<!--
+If the changes are not user facing, just write "NONE" in the release-note block below.
+-->
+
+```release-note
+NOTES:
+
+* Any Notes regarding your submitted PR, like breaking changes or else.
+
+FEATURES:
+
+* **New Source:** `aws_000_0000` ([#references_to_issue](./))
+
+ENHANCEMENTS:
+
+* feature: Add support for new version of AWS API
+
+BUG FIXES:
+
+* Prevent error from evil bugs
+```
+
+***
+
+Output from `terraform plan` command from changes you propose.
+
+```
+$ terraform plan
+
+```
+
+<!---
+Credit: 
+This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md
+
+Created: May 27, 2019 
+Last updated: July 11, 2019
+--->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,33 +1,5 @@
-## v0.2.0 (Feb 28, 2019)
+##  v0.1.0 (Oct 29, 2018)
 
 NOTES:
-* Any Notes regarding your submitted PR, like breaking changes or else.
 
-FEATURES:
-
-* **New Source:** `aws_000_0000` ([#references_to_issue](./))
-
-ENHANCEMENTS:
-
-* feature: Add support for new version of AWS API
-
-BUG FIXES:
-
-* Prevent error from evil bugs
-
-## v0.1.0 (Jan 1, 2019)
-
-NOTES:
-* Any Notes regarding your submitted PR, like breaking changes or else.
-
-FEATURES:
-
-* **New Source:** `aws_000_0000` ([#references_to_issue](./))
-
-ENHANCEMENTS:
-
-* feature: Add support for new version of AWS API
-
-BUG FIXES:
-
-* Prevent error from evil bugs
+* Initial implementation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+## v0.2.0 (Feb 28, 2019)
+
+NOTES:
+* Any Notes regarding your submitted PR, like breaking changes or else.
+
+FEATURES:
+
+* **New Source:** `aws_000_0000` ([#references_to_issue](./))
+
+ENHANCEMENTS:
+
+* feature: Add support for new version of AWS API
+
+BUG FIXES:
+
+* Prevent error from evil bugs
+
+## v0.1.0 (Jan 1, 2019)
+
+NOTES:
+* Any Notes regarding your submitted PR, like breaking changes or else.
+
+FEATURES:
+
+* **New Source:** `aws_000_0000` ([#references_to_issue](./))
+
+ENHANCEMENTS:
+
+* feature: Add support for new version of AWS API
+
+BUG FIXES:
+
+* Prevent error from evil bugs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+# Contributing Guidelines
+
+Wow, you are here to lend us your hand? Awesome!
+
+First of all, we want to thank you so much for considering to contribute to this module. Without support from you this module will not become as useful as it is.
+
+Following this guidelines will help to accelerate you delivering your contributions. In return, it also helping us addressing your issue, assessing changes, and helping you finalize your pull requests.
+
+
+## ***"It is my first time contributing, I am not sure how to do it."***
+
+No need to worry, expert was once a beginner. You can learn how from http://makeapullrequest.com/ and http://www.firsttimersonly.com/
+
+
+## ***"What can I do to contribute?"***
+
+This module is originally created to help you provision infrastructures in a secure, efficient, and reliable way. To maintain that goal, your contributions are absolutely needed. 
+
+There are many ways to contribute, from fixing typos or grammar error, improving the documentation, submitting bug reports and feature requests, also writing code which can be incorporated into the module. Should you have any questions, feel free to ask by creating an issue!
+
+
+## ***"I found a bug, what should I do?"***
+
+If you find a security vulnerability, do NOT open an issue. Please e-mail maintainer instead.
+
+If you have noticed a bug or have a question, [search the issue tracker](https://github.com/traveloka/terraform-aws-s3-bucket/issues?q=label%3Abug) first to see if someone else has already created a ticket. If it is not, then feel free to create one!
+
+To create the issue ticket you can use **Bug Report** template. By using the template it is mandatory for you to fill all asked questions where relevant.
+
+Oh, you know how to fix the bug you found? Wonderful! 
+It is going to be awesome if you not only create an issue but also submit a pull request!
+
+
+## ***"How to submit a feature request? I am sure this feature is also going to be useful for the community."***
+
+Just like submitting the bug, first you need to [search the issue tracker](https://github.com/traveloka/terraform-aws-s3-bucket/issues?q=label%3Aenhancement) to see if someone else has already created a request. If such request not exists yet, go ahead and create one!
+
+To create the issue ticket you can use **Feature Request** template. By using the template it is mandatory for you to fill all asked questions where relevant.
+
+
+## ***"I want to create and submit a pull request, any conditions should I pay attention to?"***
+
+Before start contributing, it is required for you to:
+- Ensure an issue related to the changes you want to submit is exists. If not, create an issue and start discussion there prior working on contribution. This will reduce chance of unncecessary double efforts.
+- Always sign your commits. To learn how to do so, please follow https://help.github.com/en/articles/signing-commits. If any of you commits is not signed then your PR will not be able to be merged.
+- Use Terraform and AWS provider which versions are the one listed on [README.md](README.md)
+- Execute `terraform fmt` to rewrite Terraform configuration files to a canonical format and style.
+
+All good? Then you are ready! Here are the steps you can follow to submit a PR:
+1. Create your own fork of the repository.
+2. Create a branch with a descriptive name. A good branch name would be (where issue #123 is the ticket you're working on): `123-fix-docs-typo`.
+3. Do the changes there, don't forget to execute `terraform fmt`.
+4. Commit and push the changes to your origin.
+5. Create PR from your origin branch to the upstream master.
+6. Wait for maintainer to review your code. Go or No Go decision is one of the maintainer's resposibilities, we will make sure to explain any decision we are making :)
+
+
+## ***Happy Contributing!***


### PR DESCRIPTION
## Background

Based on community standards, these files are highly recommended to be put on the repository:
- .github/CODEOWNERS
- .github/CODE_OF_CONDUCT.md
- .github/ISSUE_TEMPLATE/BUG_REPORT.md
- .github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
- .github/ISSUE_TEMPLATE/GENERAL_QUESTION.md
- .github/PULL_REQUEST_TEMPLATE.md
- CHANGELOG.md
- CONTRIBUTING.md

## Reference
- https://opensource.guide/